### PR TITLE
Fix Conversation.__str__ and admin search field

### DIFF
--- a/hexense_core/admin.py
+++ b/hexense_core/admin.py
@@ -62,7 +62,7 @@ class MessageAdmin(admin.ModelAdmin):
     }
     list_display = ('conversation', 'sender', 'gpt_package', 'timestamp')
     list_filter = ('sender', 'timestamp', 'gpt_package')
-    search_fields = ('content', 'conversation__title')
+    search_fields = ('content', 'conversation__context')
     readonly_fields = ('timestamp',)
     fields = ('conversation', 'sender', 'content', 'gpt_package', 'actions', 'timestamp')
 

--- a/hexense_core/models.py
+++ b/hexense_core/models.py
@@ -108,7 +108,9 @@ class Conversation(models.Model):
     
     # İleride GPT paket bilgisi eklenebilir
     def __str__(self):
-        return self.title or f"Conversation {self.pk}"
+        if self.context:
+            return self.context[:50]
+        return f"Conversation {self.pk}"
 
     class Meta:
         verbose_name = "Conversation"


### PR DESCRIPTION
## Summary
- make Conversation string show context snippet or ID
- update MessageAdmin search field

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68496dce3bac833099541b3c2e4d51a3